### PR TITLE
Update oic.devicemap-content.json

### DIFF
--- a/module_testing/oic.devicemap-content.json
+++ b/module_testing/oic.devicemap-content.json
@@ -2,7 +2,7 @@
   {
     "devicename": "Module Test - Actuator Device",
     "devicetype": "oic.d.test-module-actuator",
-    "vertical":   "Smart Home",
+    "vertical":   "Module",
     "resources": [
       {"resourcetypetitle": "Query Test", "resourcetypeid": "oic.r.query-test"},
       {"resourcetypetitle": "Range Test", "resourcetypeid": "oic.r.range-test"},
@@ -12,7 +12,7 @@
   {
     "devicename": "Module Test - Sensor Device",
     "devicetype": "oic.d.test-module-sensor",
-    "vertical":   "Smart Home",
+    "vertical":   "Module",
     "resources": [
       {"resourcetypetitle": "Sensor Test", "resourcetypeid": "oic.r.test-sensor"}
     ]


### PR DESCRIPTION
Updating the Vertical Profile to "Module" from "Smart Home" since the generic module devices are not defined in the Smart Home annex of the Device Spec.  This will make importing into the OCMS cleaner as well (will be under a separate Vertical of Module instead of buried in the list of Smart Home devices)